### PR TITLE
bugfix: special characters in profile name

### DIFF
--- a/PoESimpleGuild/src/survfate/poesimpleguild/Account.java
+++ b/PoESimpleGuild/src/survfate/poesimpleguild/Account.java
@@ -40,7 +40,7 @@ public class Account {
 		// Retry when timeout
 		for (int i = 0; i < 10; i++) {
 			try {
-				Document jsoupDoc = Jsoup.connect("http://www.pathofexile.com/account/view-profile/" + profile)
+				Document jsoupDoc = Jsoup.connect("http://www.pathofexile.com/account/view-profile/" + this.profile)
 						.timeout(5000).get();
 				details = jsoupDoc.getElementsByClass("details").first();
 				break;


### PR DESCRIPTION
bugfix profile -> this.profile. using the unencoded profile name caused issues with special characters